### PR TITLE
LPD-65108 composer startup fails because Gradle wants an int and gets a string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ file("ports.env").withInputStream {
 		key, value ->
 
 		if (!value.contains("-")) {
-			return [key, value]
+			return [key, value as Integer]
 		}
 
 		String[] parts = value.split("-")
@@ -187,7 +187,7 @@ file("ports.env").withInputStream {
 
 		execResult.assertNormalExitValue()
 
-		return [key, stdout.toString().trim()]
+		return [key, stdout.toString().trim() as Integer]
 	}
 }
 


### PR DESCRIPTION
This is an update for [LPD-65108](https://liferay.atlassian.net/browse/LPD-65108).
