### PR TITLE
LPD-66454 Prune deleted worktrees

### DIFF
--- a/scripts/cli/lec.sh
+++ b/scripts/cli/lec.sh
@@ -380,7 +380,7 @@ cmd_init() {
 	local worktree_name
 
 	if [[ -z "${ticket}" ]]; then
-		_prompt "LPP ticket number: " ticket
+		_prompt "ticket number: " ticket
 	fi
 	_cancelIfEmpty "${ticket}"
 

--- a/scripts/cli/lec.sh
+++ b/scripts/cli/lec.sh
@@ -354,6 +354,11 @@ _cmd_setVersion() {
 #
 
 cmd_clean() {
+	cd "$(dirname ${0})"
+	_print_step "Removing manually deleted worktrees"
+	git worktree prune
+	cd -
+
 	_checkCWDProject
 
 	(


### PR DESCRIPTION
Based on Slack feedback.

* https://liferay.slack.com/archives/C08PZA6PD46/p1758631967990579 - customer support engineers may try to reproduce an issue before the product team ticket is created, and so they would like to simply use the customer ticket ID instead of assuming there's a specific product team ticket
* https://liferay.slack.com/archives/C08PZA6PD46/p1758633468139759 - lec init command fails for a folder that the user manually deleted and is trying to re-create