### PR TITLE
LPD-66537 lec init is very slow in WSL2 in some cases

### DIFF
--- a/scripts/cli/lec.sh
+++ b/scripts/cli/lec.sh
@@ -349,6 +349,9 @@ _cmd_gw() {
 		./gradlew "${@}"
 	)
 }
+_cmd_fn() {
+	"${1}" "${@:2}"
+}
 _cmd_list() {
 	_listWorktrees
 }


### PR DESCRIPTION
This is an update for [LPD-66537](https://liferay.atlassian.net/browse/LPD-66537).
