### PR TITLE
LPD-66479 Make sure that a clustering license is present when clustering is enabled

### DIFF
--- a/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
+++ b/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
@@ -106,7 +106,7 @@ Closure<String> getLatestImageNameLocal = {
 Closure<FileCollection> copyLiferayLicenseFromDXPImage = {
 	String imageName, boolean pullImage = false ->
 
-	if ((config.useClustering || imageName == null) || !(imageName.contains(".q") || imageName.contains("latest"))) {
+	if (config.useClustering || (imageName == null) || !(imageName.contains(".q") || imageName.contains("latest"))) {
 		return null
 	}
 


### PR DESCRIPTION
This is an update for [LPD-66479](https://liferay.atlassian.net/browse/LPD-66479).
