### PR TITLE
LPD-67072 Download hotfixes on storage.cloud.google.com using gcloud CLI

### DIFF
--- a/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Config.groovy
+++ b/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Config.groovy
@@ -99,7 +99,12 @@ class Config {
 		List hotfixURLs = this.toList(project.findProperty("lr.docker.environment.hotfix.urls"))
 
 		if (!hotfixURLs.isEmpty()) {
-			this.hotfixURLs = hotfixURLs
+			this.hotfixURLs = hotfixURLs.collect { String hotfixURL ->
+				if (hotfixURL.startsWith("https://storage.cloud.google.com/")) {
+					return "gs://${hotfixURL.substring("https://storage.cloud.google.com/".length())}"
+				}
+				return hotfixURL
+			}
 		}
 
 		String arch = System.getProperty("os.arch")

--- a/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
+++ b/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
@@ -263,22 +263,73 @@ tasks.register("deleteStaleHotfixes") {
 	}
 }
 
-tasks.register("prepareHotfixes", Download) {
-	onlyIf("there are hotfix URLs") {
-		!config.hotfixURLs.isEmpty()
+tasks.register("prepareHotfixesGCP") {
+	onlyIf("there are GCP hotfix URLs") {
+		!config.hotfixURLs.findAll { String hotfixURL ->
+			hotfixURL.startsWith("gs://")
+		}.isEmpty()
 	}
 	onlyIf("using the Liferay service") {
 		config.useLiferay
 	}
 
-	dependsOn validateHotfixURLs
-	finalizedBy deleteStaleHotfixes
+	mustRunAfter validateHotfixURLs
+
+	doFirst {
+		try {
+			waitForCommand("gcloud auth print-access-token")
+		}
+		catch (Exception e) {
+			waitForCommand("gcloud auth login")
+		}
+
+		project.file("configs/common/patching").mkdirs()
+
+		config.hotfixURLs.findAll { String hotfixURL ->
+			if (!hotfixURL.startsWith("gs://")) {
+				return false
+			}
+
+			Path path = Paths.get(new URI(hotfixURL).path)
+			String hotfixName = path.getName(path.nameCount - 1).toString()
+
+			return !file("configs/common/patching/${hotfixName}").exists();
+		}.forEach {
+			String hotfixURL ->
+			waitForCommand("gcloud storage cp ${hotfixURL} configs/common/patching/")
+		}
+	}
+}
+
+tasks.register("prepareHotfixesNonGCP", Download) {
+	onlyIf("there are non-GCP hotfix URLs") {
+		!config.hotfixURLs.findAll { String hotfixURL ->
+			!hotfixURL.startsWith("gs://")
+		}.isEmpty()
+	}
+	onlyIf("using the Liferay service") {
+		config.useLiferay
+	}
+
+	mustRunAfter validateHotfixURLs
 
 	dest project.layout.dir(project.provider {project.file("configs/common/patching")})
 
 	overwrite false
 
-	src config.hotfixURLs
+	src config.hotfixURLs.findAll {
+		String hotfixURL ->
+		!hotfixURL.startsWith("gs://")
+	}
+}
+
+tasks.register("prepareHotfixes") {
+	dependsOn validateHotfixURLs
+
+	dependsOn prepareHotfixesGCP
+	dependsOn prepareHotfixesNonGCP
+
+	finalizedBy deleteStaleHotfixes
 }
 
 tasks.register("fixWorkspaceProduct") {


### PR DESCRIPTION
Updates the hotfix downloading logic to invoke the `gcloud` CLI command whenever the hotfix is stored on `storage.cloud.google.com`, which will prompt the user to allow Google Cloud CLI to download the hotfix on their behalf. This also avoids the issue with file names, because using the `cp` command copies the file as if it were stored in a directory.