### PR TITLE
LPD-69532 Only use listAdminUsers when database will be populated

### DIFF
--- a/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
+++ b/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
@@ -311,6 +311,9 @@ tasks.register("listAdminUsers") {
 	onlyIf("using an external database") {
 		config.useDatabase
 	}
+	onlyIf("database is not empty") {
+		!Util.isEmpty(project.fileTree("dumps")) || !Util.isEmpty(project.fileTree(config.dataDirectory)) || config.useLiferay
+	}
 
 	Closure<Void> listAdminUsersForCompany = {
 		String companyId, String hostname, String webId, String schema ->


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-69532

This has been tested in the following cases:
* liferay service not used, no database dumps, empty data directory --> listAdminUsers not called
* liferay service not used, database dump present --> listAdminUsers called
* liferay service not used, data directory not empty --> listAdminUsers called
* liferay service used --> listAdminUsers called
