### PR TITLE
LPD-69550 Allow glowroot directory to be exported

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,12 @@ tasks.register("exportContainerData") {
 
 		String hostPath = projectDir.relativePath(exportDir)
 
+		if (!config.glowrootEnabled) {
+			String glowrootVolume = "${config.namespace}_glowroot"
+
+			existingVolumeNames.remove(glowrootVolume)
+		}
+
 		existingVolumeNames.each {
 			String volumeName ->
 

--- a/compose-recipes/liferay/service.liferay.yaml
+++ b/compose-recipes/liferay/service.liferay.yaml
@@ -20,6 +20,8 @@ services:
             -   "${LIFERAY_GOGO_SHELL_PORT}:11311"
             -   "${LIFERAY_PORT}:8080"
         volumes:
+            -   glowroot:/opt/liferay/glowroot
             -   liferay:/opt/liferay/data
 volumes:
+    glowroot:
     liferay:

--- a/gradle.properties
+++ b/gradle.properties
@@ -119,8 +119,8 @@ lr.docker.environment.web.server.hostnames=localhost
 
 # Optional
 #
-# Set to 'true' to enable Glowroot.
-lr.docker.environment.glowroot.enabled=false
+# Set to 'false' to disable Glowroot.
+lr.docker.environment.glowroot.enabled=true
 
 # Optional
 #


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-69550

Tested in the following conditions
* exporting without glowroot enabled -- glowroot volume is not exported
* exporting with glowroot enabled -- glowroot volume is exported
* importing with glowroot enabled -- Composer starts up successfully
