### PR TITLE
LPD-83621 Add tests for validating initial startup

### DIFF
--- a/.github/workflows/validate-initial-startup.yaml
+++ b/.github/workflows/validate-initial-startup.yaml
@@ -1,0 +1,14 @@
+jobs:
+    validate-initial-startup:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    submodules: true
+            -   uses: actions/setup-java@v4
+                with:
+                    distribution: zulu
+                    java-version: "21"
+            -   run: ./scripts/vendor/bats/bin/bats ./scripts/tests/test-initial-startup.test.sh
+name: Validate initial startup
+on: [workflow_dispatch]

--- a/scripts/tests/test-initial-startup.test.sh
+++ b/scripts/tests/test-initial-startup.test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+_debug() {
+	if [[ "${DEBUG}" -gt 0 ]]; then
+		echo "    # ${*}" >&3
+	fi
+}
+_lec() {
+	"${WORKSPACE_DIR}/scripts/cli/lec.sh" "${@}"
+}
+_timestamp() {
+	date +%s
+}
+_test_initial_startup() {
+	local databaseType=${1}
+
+	_debug "RUNNING ${BATS_TEST_NAME}"
+
+	./gradlew clean start \
+		-Plr.docker.environment.service.enabled["${databaseType}"]=true \
+		-Plr.docker.environment.service.enabled[liferay]=true
+
+	local status=$?
+
+	if [[ ${status} != 0 ]]; then
+		echo "[FAILED] could not start up:"
+
+		return 1
+	fi
+}
+
+setup_file() {
+	_debug "TEARDOWN FILE ${BATS_TEST_NAME}"
+
+	WORKSPACE_DIR="$(git rev-parse --show-toplevel)"
+	export WORKSPACE_DIR
+
+	BATS_TEST_NAME_PREFIX="Test initial startup "
+	export BATS_TEST_NAME_PREFIX
+
+	LIFERAY_ENVIRONMENT_COMPOSER_HOME="${WORKSPACE_DIR}"
+	export LIFERAY_ENVIRONMENT_COMPOSER_HOME
+
+	LIFERAY_ENVIRONMENT_COMPOSER_WORKSPACES_DIR="${BATS_SUITE_TMPDIR}"
+	export LIFERAY_ENVIRONMENT_COMPOSER_WORKSPACES_DIR
+}
+setup() {
+	_debug "SETUP ${BATS_TEST_NAME}"
+
+	local name
+	name="test-initial-startup-$(_timestamp)"
+
+	_lec init "${name}" dxp-2025.q4.12
+
+	TEST_WORKSPACE_DIR="${LIFERAY_ENVIRONMENT_COMPOSER_WORKSPACES_DIR}/lec-${name}"
+	export TEST_WORKSPACE_DIR
+
+	cd "${TEST_WORKSPACE_DIR}" || exit 1
+}
+teardown() {
+	_debug "TEARDOWN ${BATS_TEST_NAME}"
+
+	docker compose down -v
+
+	_lec fn _clean "${TEST_WORKSPACE_DIR}"
+	_lec fn _removeWorktree "${TEST_WORKSPACE_DIR}"
+}
+
+@test "db2 initial startup" {
+	_test_initial_startup db2
+}
+@test "mariadb initial startup" {
+	_test_initial_startup mariadb
+}
+@test "mysql initial startup" {
+	_test_initial_startup mysql
+}
+@test "postgres initial startup" {
+	_test_initial_startup postgres
+}
+@test "sqlserver initial startup" {
+	_test_initial_startup sqlserver
+}

--- a/scripts/tests/test-initial-startup.test.sh
+++ b/scripts/tests/test-initial-startup.test.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
 
-_debug() {
-	if [[ "${DEBUG}" -gt 0 ]]; then
-		echo "    # ${*}" >&3
-	fi
-}
-_lec() {
-	"${WORKSPACE_DIR}/scripts/cli/lec.sh" "${@}"
-}
-_timestamp() {
-	date +%s
-}
+load helpers/setup
+
 _test_initial_startup() {
 	local databaseType=${1}
 
@@ -30,40 +21,18 @@ _test_initial_startup() {
 }
 
 setup_file() {
-	_debug "TEARDOWN FILE ${BATS_TEST_NAME}"
-
-	WORKSPACE_DIR="$(git rev-parse --show-toplevel)"
-	export WORKSPACE_DIR
-
 	BATS_TEST_NAME_PREFIX="Test initial startup "
 	export BATS_TEST_NAME_PREFIX
 
-	LIFERAY_ENVIRONMENT_COMPOSER_HOME="${WORKSPACE_DIR}"
-	export LIFERAY_ENVIRONMENT_COMPOSER_HOME
-
-	LIFERAY_ENVIRONMENT_COMPOSER_WORKSPACES_DIR="${BATS_SUITE_TMPDIR}"
-	export LIFERAY_ENVIRONMENT_COMPOSER_WORKSPACES_DIR
+	common_setup_file
 }
+
 setup() {
-	_debug "SETUP ${BATS_TEST_NAME}"
-
-	local name
-	name="test-initial-startup-$(_timestamp)"
-
-	_lec init "${name}" dxp-2025.q4.12
-
-	TEST_WORKSPACE_DIR="${LIFERAY_ENVIRONMENT_COMPOSER_WORKSPACES_DIR}/lec-${name}"
-	export TEST_WORKSPACE_DIR
-
-	cd "${TEST_WORKSPACE_DIR}" || exit 1
+	common_setup
 }
+
 teardown() {
-	_debug "TEARDOWN ${BATS_TEST_NAME}"
-
-	docker compose down -v
-
-	_lec fn _clean "${TEST_WORKSPACE_DIR}"
-	_lec fn _removeWorktree "${TEST_WORKSPACE_DIR}"
+	common_teardown
 }
 
 @test "db2 initial startup" {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83621

## Summary

Based on https://github.com/liferay/liferay-environment-composer/pull/252, rebased onto master with the following changes:

- Refactored test file to use shared test helpers from `scripts/tests/helpers/setup.bash` (`common_setup_file`, `common_setup`, `common_teardown`) instead of re-implementing `_debug`, `_lec`, `_timestamp`, `setup_file`, `setup`, and `teardown` inline
- Added missing trailing newline to workflow file