### PR TITLE
LPD-86935 Exclude .claude directory from source formatter

### DIFF
--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -8,6 +8,7 @@
     #
     source.formatter.excludes=\
         **/*license*.xml,\
+        .claude/**,\
         bundles/**,\
         compose-recipes/**/ldap-init.ldif,\
         exports/**,\


### PR DESCRIPTION
## Summary
- Adds `.claude/**` to `source.formatter.excludes` so Liferay's Source Formatter skips Claude Code context files (rules, hooks, settings).

## Test plan
- [x] `./gradlew formatSource -Denv.mode.ci=true` passes without touching files under `.claude/`