### PR TITLE
LPD-86518 Fix incorrect location of certificate in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -309,7 +309,7 @@ After Composer starts up, you will need to manually configure Liferay SAML to co
 
 1. Click the **Import Certificate** tab
 
-1. Select the `keystore.p12` file generated in the `compose-recipes/keystore/build` directory of the Composer project
+1. Select the `keystore.p12` file generated in the `compose-recipes/keycloak/build` directory of the Composer project
 
 1. Complete certificate import process
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86518

## Summary
- Corrects the Keycloak SAML setup instructions in `README.markdown`: the generated `keystore.p12` lives in `compose-recipes/keycloak/build`, not `compose-recipes/keystore/build`.

Original fix authored by @daniel-pinter-lr (previously PR #264 against `fix-keycloak-readme-typo`); rebased onto current master and renamed under ticket LPD-86518.