### PR TITLE
LPD-86435 Use shared liferay user for DB2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -323,8 +323,8 @@ Map<String, String> environmentMap = [:]
 
 environmentMap.put "DATA_DIRECTORY", config.dataDirectory
 environmentMap.put "DATABASE_NAME", config.databaseName
-environmentMap.put "DATABASE_USER", config.databaseUser
 environmentMap.put "DATABASE_PASSWORD", config.databasePassword
+environmentMap.put "DATABASE_USER", config.databaseUser
 environmentMap.put "NAMESPACE", config.namespace
 
 if (config.useClustering) {

--- a/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Config.groovy
+++ b/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Config.groovy
@@ -38,16 +38,16 @@ class Config {
 			this.databaseName = databaseNameProperty
 		}
 
-		String databaseUserProperty = project.findProperty("lr.docker.environment.database.user")
-
-		if (databaseUserProperty != null) {
-			this.databaseUser = databaseUserProperty
-		}
-
 		String databasePasswordProperty = project.findProperty("lr.docker.environment.database.password")
 
 		if (databasePasswordProperty != null) {
 			this.databasePassword = databasePasswordProperty
+		}
+
+		String databaseUserProperty = project.findProperty("lr.docker.environment.database.user")
+
+		if (databaseUserProperty != null) {
+			this.databaseUser = databaseUserProperty
 		}
 
 		String databasePartitioningEnabledProperty = project.findProperty("lr.docker.environment.database.partitioning.enabled")
@@ -444,8 +444,8 @@ class Config {
 	public String databaseName = "lportal"
 	public String databaseType = ""
 	public boolean databasePartitioningEnabled = false
-	public String databaseUser = ""
 	public String databasePassword = ""
+	public String databaseUser = ""
 	public String dataDirectory = "data"
 	public Map<String, String> defaultCompanyVirtualHost = null
 	public String dlStore = ""

--- a/buildSrc/src/main/groovy/docker-common.gradle
+++ b/buildSrc/src/main/groovy/docker-common.gradle
@@ -154,8 +154,8 @@ ext {
 			}
 
 			return [
-				"docker compose exec --user db2admin -it database /opt/ibm/db2/V11.5/bin/db2 connect to ${schema} > /dev/null",
-				"docker compose exec --user db2admin -it database /opt/ibm/db2/V11.5/bin/db2"
+				"docker compose exec --user ${config.databaseUser} -it database /opt/ibm/db2/V11.5/bin/db2 connect to ${schema} > /dev/null",
+				"docker compose exec --user ${config.databaseUser} -it database /opt/ibm/db2/V11.5/bin/db2"
 			].join("\n")
 		}
 

--- a/compose-recipes/db2/clustering.db2.yaml
+++ b/compose-recipes/db2/clustering.db2.yaml
@@ -2,6 +2,6 @@ services:
     liferay-cluster-node:
         environment:
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_DRIVER_UPPERCASEC_LASS_UPPERCASEN_AME=com.ibm.db2.jcc.DB2Driver
-            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=lportal
+            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=${DATABASE_USER_PASSWORD}
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_URL=jdbc:db2://database/${DATABASE_NAME}:deferPrepares=false;fullyMaterializeInputStreams=true;fullyMaterializeLobData=true;progresssiveLocators=2;progressiveStreaming=2;
-            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=db2admin
+            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=${DATABASE_USER}

--- a/compose-recipes/db2/clustering.db2.yaml
+++ b/compose-recipes/db2/clustering.db2.yaml
@@ -2,6 +2,6 @@ services:
     liferay-cluster-node:
         environment:
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_DRIVER_UPPERCASEC_LASS_UPPERCASEN_AME=com.ibm.db2.jcc.DB2Driver
-            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=${DATABASE_USER_PASSWORD}
+            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=${DATABASE_PASSWORD}
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_URL=jdbc:db2://database/${DATABASE_NAME}:deferPrepares=false;fullyMaterializeInputStreams=true;fullyMaterializeLobData=true;progresssiveLocators=2;progressiveStreaming=2;
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=${DATABASE_USER}

--- a/compose-recipes/db2/conf/prepare-database.sh
+++ b/compose-recipes/db2/conf/prepare-database.sh
@@ -12,6 +12,15 @@ _prepare_database() {
 
 		cd /database/data/${DB2INSTANCE}/backups
 
+		local old_schema
+		old_schema=$(sed -n '1s@^!"\(.*\)"\..*@\1@p' db2move.lst)
+
+		if [[ -n "${old_schema}" ]] && [[ "${old_schema}" != "${DB2INSTANCE^^}" ]]; then
+			echo "[prepare-database.sh] Rewriting schema ${old_schema} to ${DB2INSTANCE^^} in db2move.lst..."
+
+			sed -i "s/${old_schema}/${DB2INSTANCE^^}/g" db2move.lst
+		fi
+
 		db2move ${COMPOSER_DATABASE_NAME} import
 
 	elif [[ -f "$(find /database/data/${DB2INSTANCE}/backups -type f | tail -n 1)" ]]; then
@@ -42,6 +51,21 @@ _prepare_database() {
 		db2start
 
 		db2 activate db ${COMPOSER_DATABASE_NAME}
+
+		db2 connect to ${COMPOSER_DATABASE_NAME}
+
+		local restored_schema
+		restored_schema=$(db2 -x "SELECT RTRIM(SCHEMANAME) FROM SYSCAT.SCHEMATA WHERE SCHEMANAME NOT LIKE 'SYS%' AND SCHEMANAME NOT IN ('NULLID','SQLJ','SYSTOOLS','SYSPROC','SYSIBMADM','${DB2INSTANCE^^}') FETCH FIRST 1 ROW ONLY" | xargs)
+
+		if [[ "${restored_schema}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+			echo "[prepare-database.sh] Redirecting default schema to ${restored_schema}"
+
+			db2 "CREATE OR REPLACE PROCEDURE ${DB2INSTANCE^^}.LEC_SET_SCHEMA() LANGUAGE SQL SET CURRENT SCHEMA = '${restored_schema}'"
+			db2 "GRANT EXECUTE ON PROCEDURE ${DB2INSTANCE^^}.LEC_SET_SCHEMA TO PUBLIC"
+			db2 "UPDATE DB CFG FOR ${COMPOSER_DATABASE_NAME} USING CONNECT_PROC ${DB2INSTANCE^^}.LEC_SET_SCHEMA"
+		fi
+
+		db2 terminate
 	fi
 }
 

--- a/compose-recipes/db2/conf/prepare-database.sh
+++ b/compose-recipes/db2/conf/prepare-database.sh
@@ -68,10 +68,43 @@ _prepare_database() {
 			db2 "UPDATE DB CFG FOR ${COMPOSER_DATABASE_NAME} USING CONNECT_PROC ${DB2INSTANCE^^}.LEC_SET_SCHEMA"
 		fi
 
+		db2 -x "SELECT RTRIM(GRANTEE) FROM SYSCAT.DBAUTH WHERE SECURITYADMAUTH='Y' AND GRANTEETYPE='U' AND GRANTEE <> '${DB2INSTANCE^^}' FETCH FIRST 1 ROW ONLY" > /tmp/secadm_user.out
+
 		db2 terminate
 	fi
 }
 
+_grant_authorities_to_instance_owner() {
+	. /database/config/${DB2INSTANCE}/sqllib/db2profile
+
+	db2 connect to ${COMPOSER_DATABASE_NAME} user "${1}" using "${1}" > /dev/null
+
+	db2 "GRANT DBADM, DATAACCESS, ACCESSCTRL ON DATABASE TO USER ${DB2INSTANCE^^}"
+
+	db2 terminate > /dev/null
+}
+
 echo ${DB2INST1_PASSWORD} | su ${DB2INSTANCE} -c "$(declare -f _prepare_database); _prepare_database"
+
+if [[ -s /tmp/secadm_user.out ]]; then
+	secadm_user=$(xargs < /tmp/secadm_user.out)
+	rm -f /tmp/secadm_user.out
+
+	if [[ "${secadm_user}" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
+		secadm_user="${secadm_user,,}"
+
+		if ! id "${secadm_user}" &>/dev/null; then
+			echo "[prepare-database.sh] Creating OS user ${secadm_user} to recover dump's SECADM authority..."
+
+			useradd -m -s /bin/bash "${secadm_user}"
+
+			echo "${secadm_user}:${secadm_user}" | chpasswd
+		fi
+
+		echo "[prepare-database.sh] Granting DBADM to ${DB2INSTANCE^^} via ${secadm_user}..."
+
+		echo "${DB2INST1_PASSWORD}" | su "${DB2INSTANCE}" -c "$(declare -f _grant_authorities_to_instance_owner); _grant_authorities_to_instance_owner '${secadm_user}'"
+	fi
+fi
 
 echo "STARTING_UP" > /startup_log.txt

--- a/compose-recipes/db2/conf/prepare-database.sh
+++ b/compose-recipes/db2/conf/prepare-database.sh
@@ -54,8 +54,11 @@ _prepare_database() {
 
 		db2 connect to ${COMPOSER_DATABASE_NAME}
 
+		db2 -x "SELECT RTRIM(SCHEMANAME) FROM SYSCAT.SCHEMATA WHERE SCHEMANAME NOT LIKE 'SYS%' AND SCHEMANAME NOT IN ('NULLID','SQLJ','${DB2INSTANCE^^}') FETCH FIRST 1 ROW ONLY" > /tmp/restored_schema.out
+
 		local restored_schema
-		restored_schema=$(db2 -x "SELECT RTRIM(SCHEMANAME) FROM SYSCAT.SCHEMATA WHERE SCHEMANAME NOT LIKE 'SYS%' AND SCHEMANAME NOT IN ('NULLID','SQLJ','SYSTOOLS','SYSPROC','SYSIBMADM','${DB2INSTANCE^^}') FETCH FIRST 1 ROW ONLY" | xargs)
+		restored_schema=$(xargs < /tmp/restored_schema.out)
+		rm -f /tmp/restored_schema.out
 
 		if [[ "${restored_schema}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
 			echo "[prepare-database.sh] Redirecting default schema to ${restored_schema}"

--- a/compose-recipes/db2/conf/prepare-database.sh
+++ b/compose-recipes/db2/conf/prepare-database.sh
@@ -90,7 +90,6 @@ echo ${DB2INST1_PASSWORD} | su ${DB2INSTANCE} -c "$(declare -f _prepare_database
 
 if [[ -s /tmp/secadm_user.out ]]; then
 	secadm_user=$(xargs < /tmp/secadm_user.out)
-	rm -f /tmp/secadm_user.out
 
 	if [[ "${secadm_user}" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
 		secadm_user="${secadm_user,,}"
@@ -108,5 +107,7 @@ if [[ -s /tmp/secadm_user.out ]]; then
 		echo "${DB2INST1_PASSWORD}" | su "${DB2INSTANCE}" -c "$(declare -f _grant_authorities_to_instance_owner); _grant_authorities_to_instance_owner '${secadm_user}'"
 	fi
 fi
+
+rm -f /tmp/secadm_user.out
 
 echo "STARTING_UP" > /startup_log.txt

--- a/compose-recipes/db2/conf/prepare-database.sh
+++ b/compose-recipes/db2/conf/prepare-database.sh
@@ -15,7 +15,7 @@ _prepare_database() {
 		local old_schema
 		old_schema=$(sed -n '1s@^!"\(.*\)"\..*@\1@p' db2move.lst)
 
-		if [[ -n "${old_schema}" ]] && [[ "${old_schema}" != "${DB2INSTANCE^^}" ]]; then
+		if [[ -n "${old_schema}" && "${old_schema}" != "${DB2INSTANCE^^}" ]]; then
 			echo "[prepare-database.sh] Rewriting schema ${old_schema} to ${DB2INSTANCE^^} in db2move.lst..."
 
 			sed -i "s/${old_schema}/${DB2INSTANCE^^}/g" db2move.lst

--- a/compose-recipes/db2/conf/prepare-database.sh
+++ b/compose-recipes/db2/conf/prepare-database.sh
@@ -75,9 +75,11 @@ _prepare_database() {
 }
 
 _grant_authorities_to_instance_owner() {
+	local user="${1}"
+
 	. /database/config/${DB2INSTANCE}/sqllib/db2profile
 
-	db2 connect to ${COMPOSER_DATABASE_NAME} user "${1}" using "${1}" > /dev/null
+	db2 connect to ${COMPOSER_DATABASE_NAME} user "${user}" using "${user}" > /dev/null
 
 	db2 "GRANT DBADM, DATAACCESS, ACCESSCTRL ON DATABASE TO USER ${DB2INSTANCE^^}"
 

--- a/compose-recipes/db2/liferay.db2.yaml
+++ b/compose-recipes/db2/liferay.db2.yaml
@@ -5,6 +5,6 @@ services:
                 condition: service_healthy
         environment:
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_DRIVER_UPPERCASEC_LASS_UPPERCASEN_AME=com.ibm.db2.jcc.DB2Driver
-            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=lportal
+            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=${DATABASE_USER_PASSWORD}
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_URL=jdbc:db2://database:50000/${DATABASE_NAME}:deferPrepares=false;fullyMaterializeInputStreams=true;fullyMaterializeLobData=true;progresssiveLocators=2;progressiveStreaming=2;
-            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=db2admin
+            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=${DATABASE_USER}

--- a/compose-recipes/db2/liferay.db2.yaml
+++ b/compose-recipes/db2/liferay.db2.yaml
@@ -5,6 +5,6 @@ services:
                 condition: service_healthy
         environment:
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_DRIVER_UPPERCASEC_LASS_UPPERCASEN_AME=com.ibm.db2.jcc.DB2Driver
-            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=${DATABASE_USER_PASSWORD}
+            -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=${DATABASE_PASSWORD}
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_URL=jdbc:db2://database:50000/${DATABASE_NAME}:deferPrepares=false;fullyMaterializeInputStreams=true;fullyMaterializeLobData=true;progresssiveLocators=2;progressiveStreaming=2;
             -   LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=${DATABASE_USER}

--- a/compose-recipes/db2/service.db2.yaml
+++ b/compose-recipes/db2/service.db2.yaml
@@ -7,8 +7,8 @@ services:
         container_name: ${NAMESPACE}-database-db2
         environment:
             -   COMPOSER_DATABASE_NAME=${DATABASE_NAME}
-            -   DB2INSTANCE=db2admin
-            -   DB2INST1_PASSWORD=lportal
+            -   DB2INSTANCE=${DATABASE_USER}
+            -   DB2INST1_PASSWORD=${DATABASE_USER_PASSWORD}
             -   LICENSE=accept
         healthcheck:
             retries: 10
@@ -20,7 +20,7 @@ services:
             -   "${DATABASE_PORT}:50000"
         privileged: true
         volumes:
-            -   dumps:/database/data/db2admin/backups
-            -   db2:/database/data/db2admin/NODE0000
+            -   dumps:/database/data/${DATABASE_USER}/backups
+            -   db2:/database/data/${DATABASE_USER}/NODE0000
 volumes:
     db2:

--- a/compose-recipes/db2/service.db2.yaml
+++ b/compose-recipes/db2/service.db2.yaml
@@ -8,7 +8,7 @@ services:
         environment:
             -   COMPOSER_DATABASE_NAME=${DATABASE_NAME}
             -   DB2INSTANCE=${DATABASE_USER}
-            -   DB2INST1_PASSWORD=${DATABASE_USER_PASSWORD}
+            -   DB2INST1_PASSWORD=${DATABASE_PASSWORD}
             -   LICENSE=accept
         healthcheck:
             retries: 10


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86435

## Summary
This PR completes the shared database credential work that was begun in LPD-86437 by adding it to DB2. However, with DB2, additional changes were needed to ensure functionality with database imports:
1. Because binary database dumps can come from any user with any schema, we need to add an additional process to each SQL connection to make sure that all incoming unqualified queries to the liferay instance looks to the imported database schema instead.
2. Because database access is tied to the instance user, we need to grant our current user (`liferay`) access to the database, so we create a user tied to the previous instance to give ourselves permission to access the database.
3. For db2move, we need to modify the `db2move.lst` file to make sure that the tables get written to the `liferay` schema.

## Test plan
- [x] BATS `test-initial-startup` — DB2 fresh install
- [x] BATS `test-database-import` — `archives/db2/db2move_lst.tar.gz` (db2move path)
- [x] BATS `test-database-import` — `archives/db2/LPORTAL.0.db2admin.DBPART000.20260130234412.001.7z` (binary RESTORE path with foreign-instance dump)