### PR TITLE
LPD-88949 Use namespaced hostname for workspace URLs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -227,6 +227,10 @@ LIFERAY_DEBUG_PORT=8000-8009
 LIFERAY_YOURKIT_PORT=10001-10010
 ```
 
+When the workspace is running, `lec ports` prints both `http://localhost:<port>` and `http://<namespace>.localhost:<port>` for browser-facing ports. The `*.localhost` form gives each workspace a distinct hostname, so the browser tracks its session separately from other workspaces. A single workspace works fine on either URL.
+
+**Note:** macOS's OS resolver does not handle `*.localhost`. Chrome, Firefox, and Edge resolve it internally, but Safari, `curl`, `wget`, and other tools that use the OS resolver do not. macOS users of those tools should add `127.0.0.1 <namespace>.localhost` to `/etc/hosts` for each workspace.
+
 #### Enable LibreOffice integration
 
 You can enable LibreOffice integration with Liferay by setting the `lr.docker.environment.service.enabled[libreoffice]` property to `true` or `1` in `gradle.properties`.

--- a/build.gradle
+++ b/build.gradle
@@ -356,6 +356,7 @@ if (config.dlStore == "s3") {
 }
 
 environmentMap.put("DL_STORE_CLASS", config.dlStoreClass)
+environmentMap.put("LIFERAY_VALID_HOSTS", config.webserverHostnames.replace(' ', ','))
 
 environmentMap.put("MEDIA_PREVIEW_ENABLED", config.mediaPreviewEnabled)
 

--- a/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Config.groovy
+++ b/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Config.groovy
@@ -214,11 +214,9 @@ class Config {
 			this.recaptchaEnabled = recaptchaEnabledProperty.toBoolean()
 		}
 
-		def webserverHostnamesProperty = project.findProperty("lr.docker.environment.web.server.hostnames").split(',')*.trim().findAll { it }
+		def webserverHostnamesProperty = project.findProperty("lr.docker.environment.web.server.hostnames")?.split(',')*.trim()?.findAll { it } ?: []
 
-		if (webserverHostnamesProperty != null) {
-			this.webserverHostnames = webserverHostnamesProperty.join(' ')
-		}
+		this.webserverHostnames = ([this.namespace + ".localhost"] + webserverHostnamesProperty).unique().join(' ')
 
 		String webserverModSecurityEnabledProperty = project.findProperty("lr.docker.environment.web.server.modsecurity.enabled")
 

--- a/compose-recipes/liferay/service.liferay.yaml
+++ b/compose-recipes/liferay/service.liferay.yaml
@@ -9,6 +9,7 @@ services:
             -   LIFERAY_JPDA_ENABLED=true
             -   LIFERAY_DISABLE_TRIAL_LICENSE=true
             -   LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_AUTO_PERIOD_RUN=true
+            -   LIFERAY_VIRTUAL_PERIOD_HOSTS_PERIOD_VALID_PERIOD_HOSTS=${LIFERAY_VALID_HOSTS}
         healthcheck:
             interval: 5s
             start_period: 5m

--- a/scripts/cli/lec.sh
+++ b/scripts/cli/lec.sh
@@ -475,6 +475,9 @@ _getServicePorts() {
 	{{end -}}
 	EOF
 
+	local hostname
+	hostname="$(_getComposeProjectName "${projectDir}").localhost"
+
 	(
 		cd "${projectDir}" || exit 1
 
@@ -482,7 +485,27 @@ _getServicePorts() {
 			docker compose ps "${serviceName}" --format "${template}" | tail -n +3
 		else
 			docker compose ps --format "${template}" | tail -n +3
-		fi
+		fi | awk -v hostname="${hostname}" '
+			{
+				print $0
+				if ($2 ~ /^(80|443|8080|8443|9080)$/) {
+					has_browser_port = 1
+					url_pos = index($0, "http://")
+					if (url_pos == 0) url_pos = index($0, "https://")
+					if (url_pos > 0) {
+						url = substr($0, url_pos)
+						sub(/\/\/localhost:/, "//" hostname ":", url)
+						printf "%*s%s\n", url_pos - 1, "", url
+					}
+				}
+			}
+			END {
+				if (has_browser_port) {
+					print ""
+					print "Tip: Use *.localhost with multiple workspaces to keep browser sessions isolated."
+				}
+			}
+		'
 	)
 }
 _getWorktreeDir() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88949

When two LEC workspaces run at the same time, they both live on `localhost`, so the browser stores their login cookies in the same place. Signing into one workspace overwrites the other's session, and refreshing the first one bounces you to the sign-in page.

This PR makes each workspace also reachable at `<namespace>.localhost:<port>`. The browser treats that as a separate site, so each workspace gets its own login. Plain `localhost:<port>` still works for single-workspace use.