### PR TITLE
LPD-91606 Use namespaced hostname for workspace URLs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -227,9 +227,9 @@ LIFERAY_DEBUG_PORT=8000-8009
 LIFERAY_YOURKIT_PORT=10001-10010
 ```
 
-When the workspace is running, `lec ports` prints both `http://localhost:<port>` and `http://<namespace>.localhost:<port>` for browser-facing ports. The `*.localhost` form gives each workspace a distinct hostname, so the browser tracks its session separately from other workspaces. A single workspace works fine on either URL.
+When the project is running, `lec ports` prints both `http://localhost:<port>` and `http://<namespace>.localhost:<port>` for browser-facing ports. The `*.localhost` form gives each project a distinct hostname, so the browser tracks its session separately from other projects. Either URL can be used to connect to a single project.
 
-**Note:** macOS's OS resolver does not handle `*.localhost`. Chrome, Firefox, and Edge resolve it internally, but Safari, `curl`, `wget`, and other tools that use the OS resolver do not. macOS users of those tools should add `127.0.0.1 <namespace>.localhost` to `/etc/hosts` for each workspace.
+**Note:** macOS's OS resolver does not handle `*.localhost`. Chrome, Firefox, and Edge resolve it internally, but Safari, `curl`, `wget`, and other tools that use the OS resolver do not. macOS users of those tools should add `127.0.0.1 <namespace>.localhost` to `/etc/hosts` for each project.
 
 #### Enable LibreOffice integration
 

--- a/README.markdown
+++ b/README.markdown
@@ -227,6 +227,10 @@ LIFERAY_DEBUG_PORT=8000-8009
 LIFERAY_YOURKIT_PORT=10001-10010
 ```
 
+When the workspace is running, `lec ports` prints both `http://localhost:<port>` and `http://<namespace>.localhost:<port>` for browser-facing ports. The `*.localhost` form gives each workspace a distinct hostname, so the browser tracks its session separately from other workspaces. A single workspace works fine on either URL.
+
+**Note:** macOS's OS resolver does not handle `*.localhost`. Chrome, Firefox, and Edge resolve it internally, but Safari, `curl`, `wget`, and other tools that use the OS resolver do not. macOS users of those tools should add `127.0.0.1 <namespace>.localhost` to `/etc/hosts` for each workspace.
+
 #### Enable LibreOffice integration
 
 You can enable LibreOffice integration with Liferay by setting the `lr.docker.environment.service.enabled[libreoffice]` property to `true` or `1` in `gradle.properties`.

--- a/build.gradle
+++ b/build.gradle
@@ -356,6 +356,7 @@ if (config.dlStore == "s3") {
 }
 
 environmentMap.put("DL_STORE_CLASS", config.dlStoreClass)
+environmentMap.put("LIFERAY_VALID_HOSTS", config.webserverHostnames.replace(' ', ','))
 
 environmentMap.put("MEDIA_PREVIEW_ENABLED", config.mediaPreviewEnabled)
 

--- a/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Config.groovy
+++ b/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Config.groovy
@@ -214,9 +214,9 @@ class Config {
 			this.recaptchaEnabled = recaptchaEnabledProperty.toBoolean()
 		}
 
-		def webserverHostnamesProperty = project.findProperty("lr.docker.environment.web.server.hostnames").split(',')*.trim().findAll { it }
+		def webserverHostnamesProperty = project.findProperty("lr.docker.environment.web.server.hostnames")?.split(',')*.trim()?.findAll { it }
 
-		if (webserverHostnamesProperty != null) {
+		if (webserverHostnamesProperty) {
 			this.webserverHostnames = webserverHostnamesProperty.join(' ')
 		}
 

--- a/compose-recipes/liferay/service.liferay.yaml
+++ b/compose-recipes/liferay/service.liferay.yaml
@@ -9,6 +9,7 @@ services:
             -   LIFERAY_JPDA_ENABLED=true
             -   LIFERAY_DISABLE_TRIAL_LICENSE=true
             -   LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_AUTO_PERIOD_RUN=true
+            -   LIFERAY_VIRTUAL_PERIOD_HOSTS_PERIOD_VALID_PERIOD_HOSTS=${LIFERAY_VALID_HOSTS},*.localhost
         healthcheck:
             interval: 5s
             start_period: 5m

--- a/scripts/cli/lec.sh
+++ b/scripts/cli/lec.sh
@@ -463,7 +463,6 @@ _getServicePorts() {
 	local template
 
 	read -r -d '' template <<- 'EOF'
-	table NAME	CONTAINER PORT	HOST PORT	WEB LINK
 	{{$name := .Name -}}
 
 	{{range .Publishers -}}
@@ -475,13 +474,37 @@ _getServicePorts() {
 	{{end -}}
 	EOF
 
+	local hostname
+	hostname="$(_getComposeProjectName "${projectDir}").localhost"
+
 	(
 		cd "${projectDir}" || exit 1
 
-		if [[ "${serviceName}" ]]; then
-			docker compose ps "${serviceName}" --format "${template}" | tail -n +3
-		else
-			docker compose ps --format "${template}" | tail -n +3
+		local docker_output
+		# shellcheck disable=SC2086
+		docker_output="$(docker compose ps ${serviceName:+"${serviceName}"} --format "${template}" | grep -v '^$')"
+
+		if [[ -z "${docker_output}" ]]; then
+			exit
+		fi
+
+		local browser_ports="80|443|8080|8443|9080"
+
+		{
+			printf "NAME\tCONTAINER PORT\tHOST PORT\tWEB LINK\tNAMESPACED LINK\n"
+
+			while read -r name container host link; do
+				local namespaced="—"
+				if [[ "${container}" =~ ^(${browser_ports})$ ]]; then
+					namespaced="${link/localhost/${hostname}}"
+				fi
+				printf "%s\t%s\t%s\t%s\t%s\n" "${name}" "${container}" "${host}" "${link}" "${namespaced}"
+			done <<< "${docker_output}"
+		} | column -t -s $'\t'
+
+		if cut -f2 <<< "${docker_output}" | grep -qE "^(${browser_ports})\$"; then
+			echo
+			echo "Tip: Use *.localhost with multiple workspaces to keep browser sessions isolated."
 		fi
 	)
 }

--- a/scripts/cli/lec.sh
+++ b/scripts/cli/lec.sh
@@ -13,6 +13,20 @@ fi
 
 PROJECT_DIRECTORY=""
 
+_column() {
+	if [[ "$(uname)" == "Darwin" ]]; then
+		if ! command -v "$(brew --prefix util-linux)/bin/column" &>/dev/null; then
+			brew install util-linux
+		fi
+
+		"$(brew --prefix util-linux)/bin/column" "${@}"
+
+		return
+	fi
+
+	column "${@}"
+}
+
 #
 # Helper function for fzf
 #
@@ -483,10 +497,10 @@ _getServicePorts() {
 
 		docker compose ps ${serviceName:+"${serviceName}"} --format "${template}" |
 		sed -E "s@((https?://)localhost:(80|443|8080|8443|9080)),-@\1,\2${hostname}:\3@g" |
-		column -t -s ',' |
+		_column --keep-empty-lines --separator ',' --table |
 		tee /dev/tty |
 		grep -q "${hostname}" &&
-		printf "\nTip: Use the 'NAMESPACED LINK' when running multiple projects at once to keep browser sessions isolated.\n"
+		printf "Tip: Use the 'NAMESPACED LINK' when running multiple projects at once to keep browser sessions isolated.\n"
 	)
 }
 _getWorktreeDir() {

--- a/scripts/cli/lec.sh
+++ b/scripts/cli/lec.sh
@@ -463,15 +463,16 @@ _getServicePorts() {
 	local template
 
 	read -r -d '' template <<- 'EOF'
-	{{$name := .Name -}}
-
+	NAME,CONTAINER PORT,HOST PORT,WEB LINK,NAMESPACED LINK
 	{{range .Publishers -}}
-
-	{{if eq .URL "0.0.0.0" -}}
-		{{$name}}	{{.TargetPort}}	{{.PublishedPort}}	{{if eq .PublishedPort 443}}https{{else}}http{{end}}://localhost:{{.PublishedPort}}
-	{{end -}}
-
-	{{end -}}
+		{{if eq .URL "0.0.0.0"}}
+			{{- $.Name}},
+			{{- .TargetPort}},
+			{{- .PublishedPort}},
+			{{- if eq .PublishedPort 443}}https{{else}}http{{end}}://localhost:{{.PublishedPort}},
+			{{- "-"}}
+		{{end}}
+	{{- end}}
 	EOF
 
 	local hostname
@@ -480,32 +481,12 @@ _getServicePorts() {
 	(
 		cd "${projectDir}" || exit 1
 
-		local docker_output
-		# shellcheck disable=SC2086
-		docker_output="$(docker compose ps ${serviceName:+"${serviceName}"} --format "${template}" | grep -v '^$')"
-
-		if [[ -z "${docker_output}" ]]; then
-			exit
-		fi
-
-		local browser_ports="80|443|8080|8443|9080"
-
-		{
-			printf "NAME\tCONTAINER PORT\tHOST PORT\tWEB LINK\tNAMESPACED LINK\n"
-
-			while read -r name container host link; do
-				local namespaced="—"
-				if [[ "${container}" =~ ^(${browser_ports})$ ]]; then
-					namespaced="${link/localhost/${hostname}}"
-				fi
-				printf "%s\t%s\t%s\t%s\t%s\n" "${name}" "${container}" "${host}" "${link}" "${namespaced}"
-			done <<< "${docker_output}"
-		} | column -t -s $'\t'
-
-		if cut -f2 <<< "${docker_output}" | grep -qE "^(${browser_ports})\$"; then
-			echo
-			echo "Tip: Use *.localhost with multiple workspaces to keep browser sessions isolated."
-		fi
+		docker compose ps ${serviceName:+"${serviceName}"} --format "${template}" |
+		sed -E "s@((https?://)localhost:(80|443|8080|8443|9080)),-@\1,\2${hostname}:\3@g" |
+		column -t -s ',' |
+		tee /dev/tty |
+		grep -q "${hostname}" &&
+		printf "\nTip: Use the 'NAMESPACED LINK' when running multiple projects at once to keep browser sessions isolated.\n"
 	)
 }
 _getWorktreeDir() {

--- a/scripts/cli/lec.sh
+++ b/scripts/cli/lec.sh
@@ -796,7 +796,6 @@ cmd_clean() {
 	fi
 
 	_clean "${PROJECT_DIRECTORY}"
-	
 }
 cmd_exportData() {
 	_checkProjectDirectory "${PWD}"
@@ -1016,7 +1015,7 @@ cmd_restart() {
 			;;
 		esac
 	done
-	
+
 	if [[ "${FLAG_CLEAN}" -gt 0 ]]; then
 		_clean "${PROJECT_DIRECTORY}"
 	else


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91606

Workaround at the LEC layer: each workspace gets a distinct `<namespace>.localhost` hostname so browser cookies scope per workspace. Doesn't change the underlying RFC 6265 behavior — just stops LEC from steering users into the collision by default. Plain `localhost:<port>` still works for single-workspace use.